### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: golangci/golangci-lint-action@v6
+            - uses: golangci/golangci-lint-action@v7
               with:
                 version: latest
     go-test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,38 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
 linters:
   enable:
     - copyloopvar
     - durationcheck
-    - errcheck
     - forcetypeassert
     - godot
-    - goimports
-    - gofmt
-    - gosimple
-    - govet
-    - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
-    - staticcheck
-    - tenv
     - unconvert
     - unparam
-    - unused
-
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
-
-
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - (io.Closer).Close # Safe to exclude for closing HTTP response bodies in memory
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
### Description
Upgrade golangci-lint in the GitHub Action, as well as migrate the config schema from v1 to v2.


### Testing
Upgraded to golangci-lint v2.0.2 and ran `make lint` without errors. 

### Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented [Tines API schemas](https://tines.com/api/) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/