### PR TITLE
Fix Resource JSON unmarshaling

### DIFF
--- a/tines/resources.go
+++ b/tines/resources.go
@@ -156,7 +156,7 @@ func (c *Client) UpdateResource(ctx context.Context, id int, r *Resource) (*Reso
 		}
 	}
 
-	err = json.Unmarshal(body, r)
+	err = json.Unmarshal(body, &updatedRes)
 	if err != nil {
 		return &updatedRes, Error{
 			Type: ErrorTypeServer,

--- a/tines/resources_test.go
+++ b/tines/resources_test.go
@@ -209,8 +209,8 @@ func TestUpdateResource(t *testing.T) {
 		resp    string
 		payload tines.Resource
 	}{
-		{"WithValue", "", testUpdateResourceResp, tines.Resource{Name: "Test", Value: "value", TeamId: 1}},
-		{"EmptyValue", "", testUpdateEmptyResourceResp, tines.Resource{Name: "Test 2", Value: "", TeamId: 1}},
+		{"WithValue", "", testUpdateResourceResp, tines.Resource{Id: 1, Name: "Test", Value: "value", TeamId: 1}},
+		{"EmptyValue", "", testUpdateEmptyResourceResp, tines.Resource{Id: 1, Name: "Test 2", Value: "", TeamId: 1}},
 	}
 
 	for _, test := range tests {
@@ -230,7 +230,7 @@ func TestUpdateResource(t *testing.T) {
 
 			ctx := context.Background()
 
-			res, err := cli.GetResource(ctx, 1)
+			res, err := cli.UpdateResource(ctx, 1, &test.payload)
 			assert.Nil(err, "the resource should be retrieved without errors")
 			assert.IsType(&tines.Resource{}, res, "the response should be the expected type")
 			assert.Equal(test.payload.Value, res.Value, "the retrieved credential should match the request")


### PR DESCRIPTION
### Description
When updating a Tines Resource, the API response was being unmarshaled to the wrong variable, so the updated resource values would never be returned to the function caller. 

### Testing
Updated test coverage to account for this case with `make tests`

### Screenshots (if appropriate):

### Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented [Tines API schemas](https://tines.com/api/) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/